### PR TITLE
feat/rotate-logs Add log rotation, option for clique genesis, and doc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ x-quorum-def:
     start_period: 5s
   labels:
     com.quorum.consensus: ${QUORUM_CONSENSUS:-istanbul}
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: 10m
   entrypoint:
     - /bin/sh
     - -c
@@ -50,6 +55,9 @@ x-quorum-def:
       GENESIS_FILE="/examples/istanbul-genesis.json"
       if [ "${QUORUM_CONSENSUS:-istanbul}" == "raft" ]; then
         GENESIS_FILE="/examples/genesis.json"
+      fi
+      if [ "${QUORUM_CONSENSUS:-istanbul}" == "clique" ]; then
+        GENESIS_FILE="/examples/clique-genesis.json"
       fi
       NETWORK_ID=$$(cat $${GENESIS_FILE} | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
       GETH_ARGS_raft="--raft --raftport 50400"
@@ -83,6 +91,11 @@ x-tx-manager-def:
     timeout: 3s
     retries: 20
     start_period: 5s
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: 10m
   entrypoint:
     - /bin/sh
     - -c
@@ -194,7 +207,7 @@ services:
     << : *quorum-def
     hostname: node1
     ports:
-      - "22008:8545"
+      - "22000:8545"
     volumes:
       - vol1:/qdata
       - ./examples/quick:/examples:ro

--- a/readme.md
+++ b/readme.md
@@ -18,4 +18,36 @@ This script will help you install and run 5 nodes of JPMorgan's Quorum blockchai
 
 1. Check `docker ps` and you should see six containers. The health check will be available several moments after you run `docker-compose`.
 
+1. Test out geth functionality:  
+  - `docker exec -it quorum_node1_1 geth attach /qdata/dd/geth.ipc`
+  - Within geth console:  
+    `eth.accounts`
+
+
 🎉 Congrats, you now have your own Quorum consortium running on your machine!
+
+### More customizations:
+Change consensus protocol to Clique or other:
+- Add the `QUORUM_CONSENSUS` and optional `QUORUM_GETH_ARGS` environment variables:
+  ```
+  QUORUM_CONSENSUS=clique \
+  QUORUM_GETH_ARGS=" --mine --minerthreads 1--syncmode full" \
+  docker-compose up -d
+  ```
+
+- Debug logs - check for things like blocks are being mined from your `--mine` flag, 
+  or for out-of-memory errors, or a node is waiting on tessera node to startup.
+  - Ubuntu:
+    1. Check containers directory:  
+        - apt installed docker:  
+          `CONTAINER_PATH=/var/lib/docker/containers`
+        - snap installed docker:  
+          `CONTAINER_PATH=/var/snap/docker/common/var-lib-docker/containers`
+    1. `ls -l $CONTAINER_PATH`
+    1. `tail -f $CONTAINER_PATH/<container hash>/<container hash>-json.log`
+  - Mac: (Newer versions of Docker)
+    1. Enter the vm in console tab:  
+      `screen ~/Library/Containers/com.docker.docker/Data/vms/0/tty`
+    1. Within the screen session:  
+      `ls -l /var/lib/docker/containers`
+    1. `tail -f /var/lib/docker/containers/<container hash>/<container hash>-json.log`


### PR DESCRIPTION
- Add docker log rotation per container - Those logs fill up storage infinitely on default setting.
  - Setting at `5 files`, `10MB` each.
  - More explanation on finding those logs in the updated docs.
- Using environment variables to start a clique (non-default) consensus wasn't working. Fixed that in the node entrypoint script.  
  +Explanation in the doc.
- More docs.